### PR TITLE
Add new jeedom v4 API call format

### DIFF
--- a/octoprint_psucontrol_jeedom/__init__.py
+++ b/octoprint_psucontrol_jeedom/__init__.py
@@ -60,8 +60,8 @@ class PSUControl_Jeedom(octoprint.plugin.StartupPlugin,
     def send(self, id_cmd):
         # Jeedom API URL
         url = self.config['address'] + '/core/api/jeeApi.php'
-        # 3 parameters : apikey, type and id
-        params = { "apikey" : self.config['api_key'], "type" : "cmd", "id" : id_cmd }
+        # 4 parameters : plugin, apikey, type and id
+        params = { "plugin" : "virtual", "apikey" : self.config['api_key'], "type" : "cmd", "id" : id_cmd }
 
         response = None
         verify_certificate = self.config['verify_certificate']


### PR DESCRIPTION
Jeedom has different API key now. Maybe need to ask the "plugin" parameter in the settings is a good idea but I don't know python for doing the modification Tested on Jeedom 4.3.15 for a virtual API.